### PR TITLE
Fix the spelling of the Japanese goodbye

### DIFF
--- a/lonabot/bot.py
+++ b/lonabot/bot.py
@@ -117,7 +117,7 @@ GOOD_BYE = [
     'Alweda',
     'Adiós',
     'Hamba kahle',
-    'Sayonara',
+    'Sayōnara',
 ]
 
 FACES = [


### PR DESCRIPTION
Since the "o" sound in "Sayounara" is supposed to be long, it is more
correct to use the o with a dash over it, as this signifies a long vowel
sound.