### PR TITLE
Improve timezone handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 __pycache__/
 *.py[cod]
 *$py.class
+
+lonabot.db

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
-lonabot.db
+*.db

--- a/lonabot/bot.py
+++ b/lonabot/bot.py
@@ -355,8 +355,6 @@ Made with love by @Lonami and hosted by Richard ❤️
             hour, mins = map(int, m.groups())
         else:
             try:
-                # TODO This won't consider daylight saving time BS
-                # TODO Do this delta thing better
                 zone = tz[1].title()
                 delta = self._get_time_zone_delta(zone)
 

--- a/lonabot/bot.py
+++ b/lonabot/bot.py
@@ -316,7 +316,7 @@ Made with love by @Lonami and hosted by Richard ❤️
                     parse_mode='markdown',
                     disable_web_page_preview=True
                 )
-        elif due > int(datetime.utcnow().timestamp() + MAX_DELAY_TIME):
+        elif due > int(datetime.now(tz=pytz.UTC).timestamp() + MAX_DELAY_TIME):
             await self.sendSticker(chat_id=chat_id,
                                    sticker=CAN_U_DONT)
         else:
@@ -371,7 +371,7 @@ Made with love by @Lonami and hosted by Richard ❤️
                 return
 
         if delta is None:
-            now = datetime.utcnow()
+            now = datetime.now(tz=pytz.UTC)
             now = now.hour * 60 + now.minute
             remote = hour * 60 + mins
 
@@ -688,7 +688,8 @@ Made with love by @Lonami and hosted by Richard ❤️
         while self._running:
             while self._sched_reminders:
                 upcoming = self._sched_reminders.peek()
-                delta = upcoming.due - datetime.utcnow().timestamp()
+                actual_utc_now = datetime.now(tz=pytz.UTC).timestamp()
+                delta = upcoming.due - actual_utc_now
                 if delta > 1:
                     break
 
@@ -707,7 +708,7 @@ Made with love by @Lonami and hosted by Richard ❤️
     @log_exc
     async def _check_bday(self):
         while self._running:
-            day = datetime.utcnow()
+            day = datetime.now(tz=pytz.UTC)
             for bday in self.db.iter_birthdays(month=day.month, day=day.day):
                 if not self.db.has_birthday_stage(bday.id, day.year, stage=2):
                     await self._remind_bday(bday, today=True)

--- a/lonabot/bot.py
+++ b/lonabot/bot.py
@@ -259,11 +259,8 @@ Made with love by @Lonami and hosted by Richard ❤️
         msg = update.message
         chat_id = msg.chat.id
 
-        zone = self.db.get_time_zone(msg.from_.id)
-
-        if zone is None:
-            delta = self.db.get_time_delta(msg.from_.id)
-        else:
+        delta, zone = self.db.get_time_delta(msg.from_.id)
+        if zone is not None:
             delta = self._get_time_zone_delta(zone)
 
         reply_id = update.message.reply_to_message.message_id or None
@@ -382,10 +379,7 @@ Made with love by @Lonami and hosted by Richard ❤️
                 else:
                     delta -= 24 * 60 * 60
 
-        self.db.set_time_delta(update.message.from_.id, delta)
-
-        if zone is not None:
-            self.db.set_time_zone(update.message.from_.id, zone)
+        self.db.set_time_delta(update.message.from_.id, delta, zone)
 
         await self.sendMessage(chat_id=update.message.chat.id,
                                text=f"Got it! There's a difference of "
@@ -398,11 +392,8 @@ Made with love by @Lonami and hosted by Richard ❤️
         utc_now = datetime.now(timezone.utc)
 
         reminders = list(self.db.iter_reminders(chat_id, from_id))
-        zone = self.db.get_time_zone(from_id)
-        delta = None
 
-        if zone is None:
-            delta = self.db.get_time_delta(from_id)
+        delta, zone = self.db.get_time_delta(from_id)
 
         if len(reminders) == 0:
             text = "You don't have any reminder in this chat yet"

--- a/lonabot/database.py
+++ b/lonabot/database.py
@@ -32,11 +32,8 @@ class Database:
 
             c.execute('CREATE TABLE TimeDelta('
                       'UserID INTEGER PRIMARY KEY,'
-                      'Delta INTEGER NOT NULL)')
-
-            c.execute('CREATE TABLE TimeZones('
-                      'UserID INTEGER PRIMARY KEY,'
-                      'Zone TEXT NOT NULL)')
+                      'Delta INTEGER NOT NULL,'
+                      'TimeZone TEXT NULL)')
 
             c.execute('CREATE TABLE Reminders('
                       'ID INTEGER PRIMARY KEY AUTOINCREMENT,'
@@ -119,9 +116,7 @@ class Database:
             c.execute('ALTER TABLE Birthdays ADD RemindStage INTEGER')
             old = 6
         if old == 6:
-            c.execute('CREATE TABLE TimeZones('
-                      'UserID INTEGER PRIMARY KEY,'
-                      'Zone TEXT NOT NULL)')
+            c.execute('ALTER TABLE TimeDelta ADD TimeZone TEXT NULL')
 
         c.close()
 
@@ -188,35 +183,20 @@ class Database:
 
         c.close()
 
-    def set_time_delta(self, user_id, delta):
+    def set_time_delta(self, user_id, delta, zone=None):
         c = self._cursor()
         c.execute(
             'INSERT OR REPLACE INTO TimeDelta '
-            '(UserID, Delta) VALUES (?, ?)',
-            (user_id, delta)
-        )
-        c.close()
-        self._save()
-
-    def set_time_zone(self, user_id, zone):
-        c = self._cursor()
-        c.execute(
-            'INSERT OR REPLACE INTO TimeZones '
-            '(UserID, Zone) VALUES(?, ?)',
-            (user_id, zone)
+            '(UserID, Delta, TimeZone) VALUES (?, ?, ?)',
+            (user_id, delta, zone)
         )
         c.close()
         self._save()
 
     def get_time_delta(self, user_id):
         c = self._cursor()
-        c.execute('SELECT Delta FROM TimeDelta WHERE UserID = ?', (user_id,))
-        return (c.fetchone() or (None,))[0]
-
-    def get_time_zone(self, user_id):
-        c = self._cursor()
-        c.execute('SELECT Zone FROM TimeZones WHERE UserID = ?', (user_id,))
-        return (c.fetchone() or (None,))[0]
+        c.execute('SELECT Delta, TimeZone FROM TimeDelta WHERE UserID = ?', (user_id,))
+        return c.fetchone() or (None, None)
 
     def pop_reminder(self, reminder_id):
         c = self._cursor()

--- a/lonabot/utils.py
+++ b/lonabot/utils.py
@@ -247,7 +247,7 @@ def spell_number(n, allow_and=True):
 
 def spell_due_zoned(due, utc_now, zone=None, prefix=True):
     if prefix and zone is not None:
-        due_utc = datetime.fromtimestamp(due)
+        due_utc = datetime.fromtimestamp(due, tz=pytz.UTC)
         due = utc_to_local(due_utc, zone)
         due = due.strftime('%Y-%m-%d %H:%M:%S')
 
@@ -259,7 +259,7 @@ def spell_due_zoned(due, utc_now, zone=None, prefix=True):
 def spell_due(due, utc_now, utc_delta=None, prefix=True):
     if prefix and utc_delta is not None:
         # Looks like doing .utcfromtimestamp "subtracts" the +N local time…?
-        due = datetime.fromtimestamp(due + utc_delta)
+        due = datetime.fromtimestamp(due + utc_delta, tz=pytz.UTC)
         due = due.strftime('%Y-%m-%d %H:%M:%S')
         return f'due at {due}'
 
@@ -374,4 +374,6 @@ def split_message(message, known=(
 
 def utc_to_local(utc, zone):
     tz = pytz.timezone(zone)
-    return tz.fromutc(utc)
+
+    # CAUTION: `astimezone` ONLY works if `utc` is NOT a naive datetime!
+    return utc.astimezone(tz)

--- a/lonabot/utils.py
+++ b/lonabot/utils.py
@@ -3,6 +3,8 @@ import itertools
 import re
 from datetime import datetime, timedelta, timezone
 
+import pytz
+
 
 class NoDeltaError(ValueError):
     pass
@@ -243,6 +245,17 @@ def spell_number(n, allow_and=True):
     return spelt.lstrip()
 
 
+def spell_due_zoned(due, utc_now, zone=None, prefix=True):
+    if prefix and zone is not None:
+        due_utc = datetime.fromtimestamp(due)
+        due = utc_to_local(due_utc, zone)
+        due = due.strftime('%Y-%m-%d %H:%M:%S')
+
+        return f'due at {due}'
+
+    return spell_delay(int(due - utc_now.timestamp()), prefix=prefix)
+
+
 def spell_due(due, utc_now, utc_delta=None, prefix=True):
     if prefix and utc_delta is not None:
         # Looks like doing .utcfromtimestamp "subtracts" the +N local time…?
@@ -358,3 +371,7 @@ def split_message(message, known=(
                 return text, what, attr.file_id
 
     return text, None, None
+
+def utc_to_local(utc, zone):
+    tz = pytz.timezone(zone)
+    return tz.fromutc(utc)


### PR DESCRIPTION
If the user gives an actual timezone like Europe/Stockholm, we save this
into a table for use later. When somebody runs a remind command, if we
have the actual timezone saved we can then produce a more accurate
offset.

Note that this will always consider the delta from the current point in
time. Further improvement might be to look at when the reminder is
taking place (when a fixed point in time is given), and use the offset
at that point in time.

This change should be backwards compatible, for users to get the
improved timezone handling, they'll have to use the /tz command again to
insert their timezone into the new table. Users who don't, or who give a
time instead of a timezone, will get the old behaviour.

This updates #10.

Let me take a moment to talk about datetime in Python.

Python datetime sucks¹ ² ³. Why the fuck does `utcnow()` return a
naive datetime that on a subsequent call to `timestamp()` actually
returns a UTC time 2 hours in the past if your local system time has
offset +02:00? Why?

WHY?

PYTHON WHY?

1: https://drewdevault.com/2014/06/28/Python-datetime-sucks.html
2:
https://www.reddit.com/r/learnpython/comments/37mhqg/whats_up_with_the_messy_datetimetimezone_support/
3: https://twitter.com/marcan42/status/856524190853210113