### PR TITLE
Improve handling of DST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 *.token
 *.sh
+*.db
 
 __pycache__/
 *.py[cod]
 *$py.class
-*.db
-
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 *.py[cod]
 *$py.class
 *.db
+
+.vscode/

--- a/lonabot/bot.py
+++ b/lonabot/bot.py
@@ -259,9 +259,7 @@ Made with love by @Lonami and hosted by Richard ❤️
         msg = update.message
         chat_id = msg.chat.id
 
-        delta, zone = self.db.get_time_delta(msg.from_.id)
-        if zone is not None:
-            delta = self._get_time_zone_delta(zone)
+        time_delta = self.db.get_time_delta(msg.from_.id)
 
         reply_id = update.message.reply_to_message.message_id or None
 
@@ -283,7 +281,7 @@ Made with love by @Lonami and hosted by Richard ❤️
 
         utc_now = datetime.now(timezone.utc)
         try:
-            due, text = utils.parse_when(when[1], delta, utc_now)
+            due, text = utils.parse_when(when[1], time_delta, utc_now)
         except utils.NoDeltaError:
             await self.sendMessage(
                 chat_id=chat_id,
@@ -326,10 +324,7 @@ Made with love by @Lonami and hosted by Richard ❤️
                 reply_id=reply_id
             )
             self._sched_reminder(reminder_id, due)
-            if zone is None:
-                spelt = utils.spell_due(due, utc_now, delta)
-            else:
-                spelt = utils.spell_due_zoned(due, utc_now, zone)
+            spelt = utils.spell_due(due, utc_now, time_delta)
             await self.sendMessage(chat_id=chat_id,
                                    text=f'Got it! New reminder {spelt} saved')
 
@@ -393,17 +388,14 @@ Made with love by @Lonami and hosted by Richard ❤️
 
         reminders = list(self.db.iter_reminders(chat_id, from_id))
 
-        delta, zone = self.db.get_time_delta(from_id)
+        time_delta = self.db.get_time_delta(from_id)
 
         if len(reminders) == 0:
             text = "You don't have any reminder in this chat yet"
         elif len(reminders) == 1:
             reminder = reminders[0]
 
-            if zone is None:
-                due = utils.spell_due(reminder.due, utc_now, delta)
-            else:
-                due = utils.spell_due_zoned(reminder.due, utc_now, zone)
+            due = utils.spell_due(reminder.due, utc_now, time_delta)
 
             if reminder.text:
                 text = f'You have one reminder {due} here for "{reminder.text}"'
@@ -414,10 +406,7 @@ Made with love by @Lonami and hosted by Richard ❤️
                    f'reminders in this chat:'
 
             for i, reminder in enumerate(reminders, start=1):
-                if zone is None:
-                    due = utils.spell_due(reminder.due, utc_now, delta)
-                else:
-                    due = utils.spell_due_zoned(reminder.due, utc_now, zone)
+                due = utils.spell_due(reminder.due, utc_now, time_delta)
 
                 add = reminder.text or 'no text'
                 if len(add) > 40:

--- a/lonabot/database.py
+++ b/lonabot/database.py
@@ -2,6 +2,10 @@ import collections
 import sqlite3
 import threading
 
+import pytz
+
+from dataclasses import dataclass
+
 DB_VERSION = 7
 
 
@@ -10,6 +14,16 @@ Reminder = collections.namedtuple(
 
 Birthday = collections.namedtuple(
     'Birthday', 'id creator_id month day person_id person_name year_reminded remind_stage')
+
+@dataclass
+class TimeDelta:
+    delta: int
+    time_zone: str
+
+    def pytz(self):
+        if self.time_zone is None:
+            return None
+        return pytz.timezone(self.time_zone)
 
 class Database:
     def __init__(self, filename):
@@ -196,7 +210,8 @@ class Database:
     def get_time_delta(self, user_id):
         c = self._cursor()
         c.execute('SELECT Delta, TimeZone FROM TimeDelta WHERE UserID = ?', (user_id,))
-        return c.fetchone() or (None, None)
+        delta, time_zone = (c.fetchone() or (None, None))
+        return TimeDelta(delta, time_zone) if delta else None
 
     def pop_reminder(self, reminder_id):
         c = self._cursor()


### PR DESCRIPTION
When using /remind with a fixed date, the bot will now examine the UTC
offset at the target date, instead of using the current offset (which
fails when the target reminder date has different DST properties from
the current date).

Also simplifies the handling of the delta and timezone values, by
combining them in one data class.

@Lonami I placed a blank line before the VS Code entry in the gitignore since this feels like a new logical group of ignore stuff. Please let me know if it should not be there.

This will further improve the situation described in #10.