### PR TITLE
Fix ISO8601 date parsing

### DIFF
--- a/lonabot/utils.py
+++ b/lonabot/utils.py
@@ -151,7 +151,7 @@ def parse_due(due, delta, utc_now):
 
         # See: https://bugs.python.org/issue35829
         # See: https://discuss.python.org/t/parse-z-timezone-suffix-in-datetime/2220
-        d = d.replace('Z', '+01:00')
+        d = d.replace('Z', '+00:00')
         d = datetime.fromisoformat(d)
 
         # Parsing succeeded, so set the correct text now.

--- a/lonabot/utils.py
+++ b/lonabot/utils.py
@@ -149,6 +149,9 @@ def parse_due(due, delta, utc_now):
         if 'T' not in d:
             raise ValueError('Not parsing ISO date without T')
 
+        # See: https://bugs.python.org/issue35829
+        # See: https://discuss.python.org/t/parse-z-timezone-suffix-in-datetime/2220
+        d = d.replace('Z', '+01:00')
         d = datetime.fromisoformat(d)
 
         # Parsing succeeded, so set the correct text now.


### PR DESCRIPTION
Dear Python maintainers: Why do you hate ISO8601?

See: https://bugs.python.org/issue35829
See:
https://discuss.python.org/t/parse-z-timezone-suffix-in-datetime/2220