### PR TITLE
Add "remind later" feature

### DIFF
--- a/lonabot/bot.py
+++ b/lonabot/bot.py
@@ -79,8 +79,8 @@ You can set reminders by using:
 `/remind 2020-02-02T20:00:00+02:00 Optional text`
 `/remind later Optional text`
 
-`/remind later` requires you to first configure what `later` is with
-`/later 1y2mo3w4d5h6s`
+`/remind later` requires you to first configure what `later` is with e.g.
+`/later 1h30m`
 '''.strip()
 
 SAY_WHAT = (
@@ -238,9 +238,9 @@ Either by specifying your current time or [your location]({TZ_URL}).
 
 `/tz` without an argument will show your currently configured offset.
 
-You can configure what "later" means to you with:
-`/later 1y2mo3w4d5h6s`
-Where all parts are optional but at least one has to be present.
+You can configure what "later" means to you with e.g.:
+`/later 1h30m`
+`/later 2m30s`
 
 Everyone is allowed to use {MAX_REMINDERS} reminders max. No more!
 
@@ -426,7 +426,7 @@ Made with love by @Lonami and hosted by Richard ❤️
                 await self.sendMessage(
                     chat_id=update.message.chat.id,
                     text='Your current "later" delay is '
-                        f'{current_later} seconds'
+                        f'{utils.spell_delay(current_later, False)}'
                 )
             return
 
@@ -444,7 +444,7 @@ Made with love by @Lonami and hosted by Richard ❤️
         await self.sendMessage(
             chat_id=update.message.chat.id,
             text='Got it! Your "later" delay is now set to '
-                f'{delay} seconds <3'
+                f'{utils.spell_delay(delay, False)} <3'
         )
 
     @dumbot.command

--- a/lonabot/utils.py
+++ b/lonabot/utils.py
@@ -63,7 +63,7 @@ def parse_delay(when, later_delta=None):
         return iso
 
     later = when.split(maxsplit=1)
-    if later[0] == 'later' and later_delta is not None:
+    if later[0].upper() == 'LATER' and later_delta is not None:
         return later_delta, later[1].lstrip()
 
     delay = 0.0

--- a/lonabot/utils.py
+++ b/lonabot/utils.py
@@ -63,7 +63,7 @@ def parse_delay(when, later_delta=None):
         return iso
 
     later = when.split(maxsplit=1)
-    if later[0].upper() == 'LATER' and later_delta is not None:
+    if later[0].casefold() == 'later' and later_delta is not None:
         return later_delta, later[1].lstrip()
 
     delay = 0.0

--- a/lonabot/utils.py
+++ b/lonabot/utils.py
@@ -43,13 +43,13 @@ _DUE_DATE_DMY = re.compile(r'(\d{1,2})[/-](\d{1,2})[/-](\d{4})')
 _DUE_TIME = re.compile(fr'{_F}:{_F}(?::{_F})?')
 
 
-def parse_when(when, time_delta: TimeDelta, utc_now):
+def parse_when(when, time_delta: TimeDelta, utc_now, later_delta=None):
     # Returns `due` for either `delay` or `due`.
     due, text = parse_due(when, time_delta, utc_now)
     if due:
         return due, text
 
-    delay, text = parse_delay(when)
+    delay, text = parse_delay(when, later_delta)
     if delay:
         due = int(utc_now.timestamp()) + delay
         return due, text
@@ -57,10 +57,14 @@ def parse_when(when, time_delta: TimeDelta, utc_now):
     return None, None
 
 
-def parse_delay(when):
+def parse_delay(when, later_delta=None):
     iso = _parse_delay_iso(when)
     if iso:
         return iso
+
+    later = when.split(maxsplit=1)
+    if later[0] == 'later' and later_delta is not None:
+        return later_delta, later[1].lstrip()
 
     delay = 0.0
     while True:


### PR DESCRIPTION
 * Configure what "later" is with `/later <time string>`
 * Use it with `/remind later reminder text here`

Where `<time string>` is of the format `1y2mo3w4d5h6s` where each part
is optional but at least one has to be present.

This implements #19.