### PR TITLE
Add show command for reminders

### DIFF
--- a/lonabot/bot.py
+++ b/lonabot/bot.py
@@ -550,7 +550,6 @@ Made with love by @Lonami and hosted by Richard ❤️
 
         await self.sendMessage(chat_id=chat_id, text=text)
 
-
     @dumbot.command
     async def inspect(self, update):
         chat_id = update.message.chat.id

--- a/lonabot/bot.py
+++ b/lonabot/bot.py
@@ -588,11 +588,9 @@ Made with love by @Lonami and hosted by Richard ❤️
                 utc_now = datetime.now(timezone.utc)
                 time_delta = self.db.get_time_delta(from_id)
                 spelt = utils.spell_due(reminder.due, utc_now, time_delta)
-                # Figure out how to make proper message links
-                reply_text = f"(reply to https://t.me/c/{chat_id}/{reminder.reply_to})\n" if reminder.reply_to else ''
                 text = f'''
 **Reminder {which + 1}:**
-{reminder.text}
+{reminder.text or '(no text)'}
 
 __{spelt}__
 '''.strip()

--- a/lonabot/bot.py
+++ b/lonabot/bot.py
@@ -225,8 +225,8 @@ Hi! I'm {self._me.first_name.title()} and running in "reminder" mode.
 You can list previous reminders with:
 `/status`
 
-You can inspect a specific reminder with:
-`/inspect 2` for the 2 in `/status`
+You can show a specific reminder with:
+`/show 2` for the 2 in `/status`
 
 You can clear previous reminders with:
 `/clear next` for the closest one
@@ -551,7 +551,7 @@ Made with love by @Lonami and hosted by Richard ❤️
         await self.sendMessage(chat_id=chat_id, text=text)
 
     @dumbot.command
-    async def inspect(self, update):
+    async def show(self, update):
         chat_id = update.message.chat.id
         from_id = update.message.from_.id
         which = update.message.text.split(maxsplit=1)
@@ -559,8 +559,8 @@ Made with love by @Lonami and hosted by Richard ❤️
         if len(which) == 1:
             await self.sendMessage(
                 chat_id=chat_id,
-                text='Please specify the reminder to inspect using the number '
-                     'shown in /status (no quotes!), such as /inspect 2'
+                text='Please specify the reminder to show using the number '
+                     'shown in /status (no quotes!), such as /show 2'
             )
             return
 
@@ -571,7 +571,7 @@ Made with love by @Lonami and hosted by Richard ❤️
             shrug = b'\xf0\x9f\xa4\xb7\xe2\x80\x8d\xe2\x99\x80\xef\xb8\x8f'
             await self.sendMessage(
                 chat_id=chat_id,
-                text=f'Nothing to inspect {str(shrug, encoding="utf-8")}'
+                text=f'Nothing to show {str(shrug, encoding="utf-8")}'
             )
             return
 

--- a/lonabot/database.py
+++ b/lonabot/database.py
@@ -188,6 +188,24 @@ class Database:
         self._save()
         return row is not None
 
+    def get_nth_reminder(self, chat_id, from_id, n):
+        c = self._cursor()
+        c.execute('SELECT * FROM Reminders WHERE ChatID = ? AND '
+                  'CreatorID = ? ORDER BY Due ASC', (chat_id, from_id))
+        row = c.fetchone()
+
+        while row and n:
+            n -= 1
+            row = c.fetchone()
+
+        result = None
+        if row:
+            result = Reminder(*row)
+
+        c.close()
+
+        return result
+
     def iter_reminders(self, chat_id=None, from_id=None):
         c = self._cursor()
         if chat_id:


### PR DESCRIPTION
`/show <#>` allows a user to inspect the reminder with number `#`
(as reported by the `/status` command).

Implements #28.

Something that might also be nice is linking to the message a reminder is a reply to (if any). It's a bit limited in that it seems you can only do this in super(?) groups. In DMs it's not possible at all. Maybe something for a future PR.