### PR TITLE
Add link to replied message if possible

### DIFF
--- a/lonabot/bot.py
+++ b/lonabot/bot.py
@@ -585,13 +585,19 @@ Made with love by @Lonami and hosted by Richard ❤️
 
             if reminder:
                 utc_now = datetime.now(timezone.utc)
+                title = f'Reminder {which + 1}'
                 time_delta = self.db.get_time_delta(from_id)
+                reply_link = None
+                if reminder.reply_to is not None:
+                    reply_link = utils.get_message_link(chat_id, reminder.reply_to)
+                if reply_link:
+                    title = f'<a href="{reply_link}">Reminder {which + 1}</a>'
                 spelt = utils.spell_due(reminder.due, utc_now, time_delta)
                 text = f'''
-**Reminder {which + 1}:**
+<b>{title}:</b>
 {reminder.text or '(no text)'}
 
-__{spelt}__
+<i>{spelt}</i>
 '''.strip()
             else:
                 text = 'That reminder does not exist :('
@@ -599,7 +605,7 @@ __{spelt}__
         except ValueError:
             text = 'Er, that was not a valid number?'
 
-        await self.sendMessage(chat_id=chat_id, text=text, parse_mode='markdown')
+        await self.sendMessage(chat_id=chat_id, text=text, parse_mode='html')
 
 
     # Birthdays

--- a/lonabot/utils.py
+++ b/lonabot/utils.py
@@ -395,6 +395,19 @@ def split_message(message, known=(
 
     return text, None, None
 
+
+def get_message_link(chat_id, message_id):
+    if chat_id >= 0:
+        return None
+
+    chat_id = -chat_id
+    if chat_id > 1000000000000:
+        chat_id -= 1000000000000
+        return f"https://t.me/c/{chat_id}/{message_id}"
+
+    return None
+
+
 def utc_to_local(utc, zone):
     tz = pytz.timezone(zone)
 


### PR DESCRIPTION
If a reminder is a reply to a message, include a link to that message
when a user inspects a reminder using the `/show` command.

Since message links only works in "channels" (which includes super
groups, but not basic groups), the link will not show in other chat
types.

Also switched to HTML markup since Telegram's version of "markdown" doesn't support nesting bold inside a link or vice-versa.